### PR TITLE
Fix regex for compound keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var MongooseError = require('mongoose/lib/error');
 var Promise = require('promise');
 
-var regex = /index:\s*.+?\.\$(\S*)\s*dup key:\s*\{.*?:\s*"(.*)"\s*\}/;
+var regex = /index:\s*.+?\.\$(\S*)\s*dup key:\s*\{.*?:\s*"(.*)".*?\}/;
 
 /**
  * Beautifies an E11000 or 11001 (unique constraint fail) Mongo error
@@ -47,6 +47,8 @@ function beautify(err, collection, map, callback) {
 
             callback(dbErr);
         });
+    } else {
+        callback(err);
     }
 }
 


### PR DESCRIPTION
I had a problem with processing of some of generated errors. I got error like:
```
E11000 duplicate key error index: broadsend_test.users.$email_1_deleted_1 dup key: { : "user@domain.com", : 0 }
```

And regexp failed to match this message becaus of , : 0 in the end right before closing }
Probably you'll get this type of message if you'll use compound unique key. So I changed regexp to match this string too.

Also I faced an issue that if regexp not matched, callback never called, because this situation was not handled. So I fixed this one too and now it regexp not matched then it will just call callback with original error.